### PR TITLE
Update python bazel rules version to 0.37.2 to unlock Python 3.13

### DIFF
--- a/builder/python/deps.bzl
+++ b/builder/python/deps.bzl
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def deps(use_patched_version=False):
     http_archive(
         name = "rules_python",
-        sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
-        strip_prefix = "rules_python-0.31.0",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
+        sha256 = "c6fb25d0ba0246f6d5bd820dd0b2e66b339ccc510242fd4956b9a639b548d113",
+        strip_prefix = "rules_python-0.37.2",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.37.2/rules_python-0.37.2.tar.gz",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We update python bazel rules version to [0.37.2](https://github.com/bazelbuild/rules_python/releases) to unlock Python 3.13.

## What are the changes implemented in this PR?

We update python bazel rules version to 0.37.2 to unlock Python 3.13.