### PR TITLE
Allow loader options when loading YAML

### DIFF
--- a/common/java/BUILD
+++ b/common/java/BUILD
@@ -37,8 +37,8 @@ assemble_maven(
     version_overrides = version(artifacts_org = artifacts, artifacts_repo={}),
     project_name = "TypeDB Common",
     project_description = "TypeDB Common classes and tools",
-    project_url = "https://github.com/typedb/typeql",
-    scm_url = "https://github.com/typedb/typeql",
+    project_url = "https://github.com/typedb/typedb-dependencies",
+    scm_url = "https://github.com/typedb/typedb-dependencies",
 )
 
 deploy_maven(

--- a/common/java/yaml/YAML.java
+++ b/common/java/yaml/YAML.java
@@ -23,9 +23,18 @@ public abstract class YAML {
         return wrap(new org.yaml.snakeyaml.Yaml().load(yaml));
     }
 
+    public static YAML load(java.lang.String yaml, org.yaml.snakeyaml.LoaderOptions loaderOptions) {
+        return wrap(new org.yaml.snakeyaml.Yaml(loaderOptions).load(yaml));
+    }
+
     public static YAML load(Path filePath) throws FileNotFoundException {
         FileInputStream inputStream = new FileInputStream(filePath.toFile());
         return wrap(new org.yaml.snakeyaml.Yaml().load(inputStream));
+    }
+
+    public static YAML load(Path filePath, org.yaml.snakeyaml.LoaderOptions loaderOptions) throws FileNotFoundException {
+        FileInputStream inputStream = new FileInputStream(filePath.toFile());
+        return wrap(new org.yaml.snakeyaml.Yaml(loaderOptions).load(inputStream));
     }
 
     private static YAML wrap(Object yaml) {


### PR DESCRIPTION
## Usage and product changes

Allow setting `snakeyaml.LoaderOptions` when loading YAML

## Motivation

We have run into issues caused by YAML alias count limits that we would like to resolve by modifying that limit - which is done for `snakeyaml` through the `LoaderOptions` object.

## Implementation

We add alternative implementations of `load` that take a `snakeyaml.LoaderOptions` and use it when constructing the `snakeyaml.Yaml` object.
