### PR TITLE
Merge crate properties by path

### DIFF
--- a/tool/ide/RustManifestSyncer.kt
+++ b/tool/ide/RustManifestSyncer.kt
@@ -171,7 +171,7 @@ class RustManifestSyncer : Callable<Unit> {
         private fun loadSyncProperties(bazelBin: File): List<TargetProperties> {
             return findSyncPropertiesFiles(bazelBin)
                     .map { TargetProperties.fromPropertiesFile(it, workspaceRefs) }
-                    .groupBy { Pair(it.name, it.path) }.values
+                    .groupBy { Pair(it.name, it.cratePath) }.values
                     .map { TargetProperties.mergeList(it) }
                     .run { attachTestAndBuildProperties(this) }
         }


### PR DESCRIPTION
## Usage and product changes

When two library targets with the same crate name and path appear among the bazel rust targets, we assume them to refer to the same crate, but with different configuration (e.g., different set of enabled features).

We were incorrectly using the properties file paths (unique per target) to merge the properties rather than the project paths.

## Motivation


## Implementation
