### PR TITLE
Add declared crate features to the Rust sync tool

### DIFF
--- a/builder/rust/cargo/project_aspect.bzl
+++ b/builder/rust/cargo/project_aspect.bzl
@@ -24,8 +24,8 @@ CrateInfo = provider(fields = [
     "workspace_name",    # str
     "crate_path",        # str
     "version",           # str
+    "enabled_features",  # List[str]
     "features",          # List[str]
-    "declared_features", # List[str]
     "deps",              # List[target]
     "transitive_deps",   # List[target]
     "build_deps",        # List[target]
@@ -103,7 +103,7 @@ rust_cargo_properties_aspect = aspect(
 )
 
 def _crate_info(ctx, target):
-    declared_features = []
+    features = []
     if _is_universe_crate(target):
         crate_name = str(target.label).split(".")[0].rsplit("-", 1)[0].removeprefix("@crates__")
     else:
@@ -113,7 +113,7 @@ def _crate_info(ctx, target):
                 crate_name = tag.split("=")[1]
             elif tag.startswith("declared-features"):
                 feature_str = tag.split("=")[1]
-                declared_features = [f.strip() for f in feature_str.split(",") if f.strip()]
+                features = [f.strip() for f in feature_str.split(",") if f.strip()]
 
     workspace_name = target.label.workspace_name
     crate_path = target.label.package
@@ -126,8 +126,8 @@ def _crate_info(ctx, target):
         workspace_name = workspace_name,
         crate_path = crate_path,
         version = getattr(ctx.rule.attr, "version", "0.0.0"),
-        features = getattr(ctx.rule.attr, "crate_features", []),
-        declared_features = declared_features,
+        enabled_features = getattr(ctx.rule.attr, "crate_features", []),
+        features = features,
         deps = deps,
         transitive_deps = transitive_deps,
         build_deps = _crate_build_deps(ctx, target),
@@ -233,8 +233,8 @@ def _get_properties(target, ctx, source_files, crate_info):
     properties = {}
     properties["name"] = crate_info.crate_name
     properties["path"] = crate_info.crate_path
+    properties["enabled.features"] = ",".join(crate_info.enabled_features)
     properties["features"] = ",".join(crate_info.features)
-    properties["declared_features"] = ",".join(crate_info.declared_features)
     properties["target.name"] = target.label.name
     properties["type"] = target_type
     properties["version"] = crate_info.version
@@ -266,8 +266,8 @@ def _crate_deps_info(target, crate_info):
             repository_relative_path = target_to_root + "/" + root_to_dep
             location = "path=../{};localpath={}".format(dependency_info.crate_name, repository_relative_path)
 
-        features = ",".join(dependency_info.features)
-        info = location + (";features={}".format(features) if features else "")
+        enabled_features = ",".join(dependency_info.enabled_features)
+        info = location + (";enabled.features={}".format(enabled_features) if enabled_features else "")
         deps_info[dependency_info.crate_name] = info
     return deps_info
 

--- a/tool/ide/RustManifestSyncer.kt
+++ b/tool/ide/RustManifestSyncer.kt
@@ -402,22 +402,22 @@ class RustManifestSyncer : Callable<Unit> {
         }
 
         data class TargetProperties(
-            val path: File,
-            val name: String,
-            val targetName: String,
-            val cratePath: String,
-            val type: Type,
-            val enabledFeatures: Collection<String>,
-            val features: Collection<String>,
-            val version: String,
-            val edition: String?,
-            val entryPointPath: Path?,
-            val buildDeps: Collection<String>,
-            val deps: Collection<Dependency>,
-            val bins: MutableCollection<TargetProperties>,
-            val tests: MutableCollection<TargetProperties>,
-            val benches: MutableCollection<TargetProperties>,
-            val buildScripts: MutableCollection<TargetProperties>,
+                val path: File,
+                val name: String,
+                val targetName: String,
+                val cratePath: String,
+                val type: Type,
+                val enabledFeatures: Collection<String>,
+                val features: Collection<String>,
+                val version: String,
+                val edition: String?,
+                val entryPointPath: Path?,
+                val buildDeps: Collection<String>,
+                val deps: Collection<Dependency>,
+                val bins: MutableCollection<TargetProperties>,
+                val tests: MutableCollection<TargetProperties>,
+                val benches: MutableCollection<TargetProperties>,
+                val buildScripts: MutableCollection<TargetProperties>,
         ) {
             val cargoWorkspaceDir get() = path.parentFile.resolve(targetName + CARGO_WORKSPACE_SUFFIX)
 


### PR DESCRIPTION
## Usage and product changes
Introduce `declared_features` to the Rust sync tool, parsed from the tags of Bazel `rust_` targets, to generate `Cargo.toml` files with predeclared features that are not automatically used in the dependent targets (this happens with `crate_features`).

## Motivation
We need a way to declare features without their automatic usage to be able to activate them manually through `cargo` only when needed.

## Implementation
Parse `tags` in order to search for a new tag containing a list of declared features. Save these features into a new separate field which is then passed to the crate features declaration.
