### PR TITLE
Introduce a newer zlib dependency for the gRPC rules

### DIFF
--- a/builder/proto_grpc/rust/compile.rs
+++ b/builder/proto_grpc/rust/compile.rs
@@ -11,7 +11,7 @@ fn main() -> std::io::Result<()> {
     tonic_build::configure()
         .server_mod_attribute(".", "#[allow(non_camel_case_types)]")
         .client_mod_attribute(".", "#[allow(non_camel_case_types)]")
-        .compile(&protos, &[
+        .compile_protos(&protos, &[
             env::var("PROTOS_ROOT").expect("PROTOS_ROOT environment variable is not set")
         ])
 }


### PR DESCRIPTION
## Usage and product changes
Enable operating systems using Apple Clang 17+ (e.g., MacOS 15.5) to build TypeDB's gRPC dependency by overriding a gRPC's transitive dependency on an older version of `zlib` by the newest version of `zlib`.

## Motivation
It is impossible to build any application using our gRPC dependencies because of a new compilation error related to zlib:
```
external/zlib/BUILD.bazel:32:11: Compiling zutil.c [for tool] failed: (Exit 1): wrapped_clang failed: error executing command (from target @zlib//:zlib) external/local_config_cc/wrapped_clang '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -g0 -O2 -DNDEBUG '-DNS_BLOCK_ASSERTIONS=1' ... (remaining 34 arguments skipped)
....
In file included from external/zlib/zutil.c:10:
In file included from external/zlib/gzguts.h:21:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/usr/include/stdio.h:61:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/usr/include/_stdio.h:318:7: error: expected ')'
```
This issue was flagged in multiple open-source repositories like: https://github.com/ahrm/sioyek/issues/1361

## Implementation
The best solution would be to upgrade our gRPC dependencies, which are likely to use a newer version of `zlib`. However, we are unable to do so because we already used the last version of the gRPC rules before their transition to modules, which are not currently supported by our infrastructure.

Thus, the solution is to override the `zlib` dependency before its older version is introduced in the dependency tree. We need to add a small Bazel rule to build the library from its source code.