### PR TITLE
Fix "Open PR" tool logging tokens

### DIFF
--- a/tool/github/OpenPR.kt
+++ b/tool/github/OpenPR.kt
@@ -6,6 +6,7 @@
 
 package com.typedb.dependencies.tool.github
 
+import java.lang.System.getenv
 import org.kohsuke.github.GitHub
 import picocli.CommandLine
 import java.util.concurrent.Callable
@@ -32,8 +33,7 @@ object OpenPR: Callable<Int> {
     @CommandLine.Option(names = ["--username"], description = ["The GitHub username of the user opening the PR"])
     private var username: String = DEFAULT_USERNAME
 
-    @CommandLine.Option(names = ["--token"], description = ["The GitHub authentication token"])
-    private lateinit var token: String
+    private var token: String = getenv("OPEN_PR_GITHUB_TOKEN") ?: throw RuntimeException("OPEN_PR_GITHUB_TOKEN environment variable must be set")
 
     @JvmStatic
     fun main(args: Array<String>): Unit = exitProcess(CommandLine(OpenPR).execute(*args))


### PR DESCRIPTION
## Usage and product changes

We fix a bug where our Open GitHub PR tool would log the token passed into it.

## Motivation

Logging tokens is bad.

## Implementation

Previously the token was passed in via a CLI argument. Now it uses an environment variable instead.

----
⚠️ This will require further changes downstream in consumer repos. They will need to set the following environment variable: `OPEN_PR_GITHUB_TOKEN`.
