### PR TITLE
Fix checkstyle build

### DIFF
--- a/builder/nodejs/defs.bzl
+++ b/builder/nodejs/defs.bzl
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 load("@aspect_rules_ts//ts:defs.bzl", aspect_ts_project = "ts_project")
 
 def ts_project(name, env = {}, **kwargs):


### PR DESCRIPTION
## Usage and product changes
Add license header to `builder/nodejs/defs.bzl`.

## Motivation


## Implementation
