### PR TITLE
Introduces rust_toolchain_versioned to pin rust version in all downstream toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,11 +12,10 @@ workspace(name = "typedb_dependencies")
 # Load //builder/rust
 load("//builder/rust:deps.bzl", rust_deps = "deps")
 rust_deps()
-
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies")
 rules_rust_dependencies()
-load("@rules_rust//rust:defs.bzl", "rust_common")
-rust_register_toolchains(edition = "2021", rust_analyzer_version = rust_common.default_version)
+load("//builder/rust:versions.bzl", "rust_toolchain_versioned")
+rust_toolchain_versioned()
 
 # Load //builder/python
 load("//builder/python:deps.bzl", "rules_python")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,8 @@ load("//builder/rust:deps.bzl", rust_deps = "deps")
 rust_deps()
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies")
 rules_rust_dependencies()
+load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
+rust_analyzer_dependencies()
 load("//builder/rust:versions.bzl", "rust_toolchain_versioned")
 rust_toolchain_versioned()
 

--- a/builder/rust/versions.bzl
+++ b/builder/rust/versions.bzl
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 load("@rules_rust//rust:repositories.bzl", "rust_register_toolchains", "rust_analyzer_toolchain_tools_repository")
-load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
 load("@rules_rust//rust:defs.bzl", "rust_common")
 
 RUST_VERSION_TYPEDB = "1.81.0"

--- a/builder/rust/versions.bzl
+++ b/builder/rust/versions.bzl
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@rules_rust//rust:repositories.bzl", "rust_register_toolchains", "rust_analyzer_toolchain_tools_repository")
+load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
+load("@rules_rust//rust:defs.bzl", "rust_common")
+
+RUST_VERSION_TYPEDB = "1.81.0"
+def rust_toolchain_versioned():
+    rust_register_toolchains(
+        edition = "2021",
+        extra_target_triples = [
+            "aarch64-apple-darwin",
+            "aarch64-unknown-linux-gnu",
+            "x86_64-apple-darwin",
+            "x86_64-pc-windows-msvc",
+            "x86_64-unknown-linux-gnu",
+        ],
+        rust_analyzer_version = RUST_VERSION_TYPEDB,
+        versions = [RUST_VERSION_TYPEDB],
+    )
+    rust_analyzer_toolchain_tools_repository(
+        name = "rust_analyzer_toolchain_tools",
+        version = RUST_VERSION_TYPEDB,
+    )


### PR DESCRIPTION
## Usage and product changes
Introduces rust_toolchain_versioned to pin rust version in all downstream toolchains

## Motivation
Have a single function so each repository does not independently set version, supported targets and other toolchain details


