### PR TITLE
Add openai-java maven artifact

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -102,6 +102,9 @@ artifacts = {
     "com.newrelic.logging:logback": "3.1.0",
     "com.newrelic.telemetry:telemetry-core": "0.16.0",
     "com.newrelic.telemetry:telemetry-http-okhttp": "0.16.0",
+    "com.openai:openai-java": "3.5.3",
+    "com.openai:openai-java-client-okhttp": "3.5.3",
+    "com.openai:openai-java-core": "3.5.3",
     "com.posthog.java:posthog": "1.1.1",
     "com.quantego:clp-java": {
         "exclude": ["com.google.android.tools:dx"],


### PR DESCRIPTION
## Usage and product changes

We add the openai-java maven artifact

## Motivation

To access the OpenAI platform via JVM applications, most notably TypeDB Cloud

## Implementation

The usual